### PR TITLE
Fix harvesting and berry consumption bugs

### DIFF
--- a/frontend/src/Components/Api.tsx
+++ b/frontend/src/Components/Api.tsx
@@ -214,25 +214,8 @@ const Api = (props) => {
       }
       if (messageObject.harvestCompleted) {
         completeHarvest(messageObject.treeId);
-        if (messageObject.playerId === userConnectionId) {
-          // Add berry to inventory for the harvesting player
-          const berryType = messageObject.berryType || 'blueberry';
-          const berryConfigs = {
-            blueberry: { name: 'Blueberry', icon: '/blueberry.svg' },
-            strawberry: { name: 'Strawberry', icon: '/strawberry.svg' },
-            greenberry: { name: 'Greenberry', icon: '/greenberry.svg' },
-            goldberry: { name: 'Goldberry', icon: '/goldberry.svg' },
-          };
-          const config = berryConfigs[berryType] || berryConfigs.blueberry;
-
-          addItem({
-            type: "berry",
-            subType: berryType,
-            name: config.name,
-            icon: config.icon,
-            quantity: 1,
-          });
-        }
+        // Note: Berry addition is handled by backend and synced via inventory validation
+        // Removing duplicate frontend addition to fix random berry quantities bug
       }
 
       // Handle inventory synchronization from backend

--- a/frontend/src/Components/Inventory.tsx
+++ b/frontend/src/Components/Inventory.tsx
@@ -52,6 +52,10 @@ const Inventory = memo((props: InventoryProps) => {
         itemId: item.id
       };
       websocketConnection.send(JSON.stringify(payload));
+
+      // Optimistically remove 1 berry from frontend inventory
+      // Backend will validate and sync if there's a mismatch
+      removeItem(item.id, 1);
     }
   };
 

--- a/frontend/src/__tests__/store.test.js
+++ b/frontend/src/__tests__/store.test.js
@@ -145,14 +145,54 @@ describe('Inventory Store Drag and Drop', () => {
     let state = useInventoryStore.getState();
     const item1Id = state.items[0].id;
 
-    // Remove first item to create null slot
-    store.removeItem(item1Id);
+    // Remove 1 berry from the stack (new quantity-aware behavior)
+    store.removeItem(item1Id, 1);
 
     state = useInventoryStore.getState();
     const blueberryCount = store.getItemCount('berry', 'blueberry');
     const strawberryCount = store.getItemCount('berry', 'strawberry');
-    expect(blueberryCount).toBe(0); // Blueberry was removed
-    expect(strawberryCount).toBe(2); // Strawberry should remain
+    expect(blueberryCount).toBe(2); // 3 - 1 = 2 blueberries remaining
+    expect(strawberryCount).toBe(2); // Strawberry should remain unchanged
+
+    // Remove all remaining blueberries to test complete removal
+    store.removeItem(item1Id, 2);
+
+    state = useInventoryStore.getState();
+    const blueberryCountAfter = store.getItemCount('berry', 'blueberry');
+    expect(blueberryCountAfter).toBe(0); // All blueberries removed
+    expect(state.items[0]).toBeNull(); // Slot should be null when quantity reaches 0
+  });
+
+  it('should handle berry consumption correctly (quantity-aware removal)', () => {
+    // Test the specific berry consumption behavior
+    const berryStack = { type: 'berry', subType: 'blueberry', name: 'Blueberry', quantity: 5 };
+
+    store.addItem(berryStack);
+
+    let state = useInventoryStore.getState();
+    const berryId = state.items[0].id;
+
+    // Consume 1 berry (like eating)
+    store.removeItem(berryId, 1);
+
+    state = useInventoryStore.getState();
+    expect(state.items[0]).not.toBeNull(); // Item should still exist
+    expect(state.items[0].quantity).toBe(4); // Quantity should be reduced by 1
+    expect(store.getItemCount('berry', 'blueberry')).toBe(4);
+
+    // Consume another berry
+    store.removeItem(berryId, 1);
+
+    state = useInventoryStore.getState();
+    expect(state.items[0].quantity).toBe(3); // Quantity should be reduced by 1 again
+    expect(store.getItemCount('berry', 'blueberry')).toBe(3);
+
+    // Consume all remaining berries at once
+    store.removeItem(berryId, 3);
+
+    state = useInventoryStore.getState();
+    expect(state.items[0]).toBeNull(); // Item should be completely removed
+    expect(store.getItemCount('berry', 'blueberry')).toBe(0);
   });
 
   it('should initialize with exactly 28 slots', () => {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -149,9 +149,24 @@ export const useInventoryStore = create((set, get) => ({
       return { items: newItems };
     }),
 
-  removeItem: (itemId) =>
+  removeItem: (itemId, quantityToRemove = 1) =>
     set((state) => ({
-      items: state.items.map(item => item && item.id === itemId ? null : item),
+      items: state.items.map(item => {
+        if (!item || item.id !== itemId) return item;
+
+        const currentQuantity = item.quantity || 1;
+
+        // For stackable items (like berries), decrement quantity
+        if (item.type === 'berry' && currentQuantity > quantityToRemove) {
+          return {
+            ...item,
+            quantity: currentQuantity - quantityToRemove
+          };
+        }
+
+        // For non-stackable items or when quantity reaches 0 or below, remove entirely
+        return null;
+      }),
     })),
 
   clearInventory: () =>


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs in the harvesting and berry consumption systems:

### Bug 1: Random Berry Quantities on Harvest
**Problem**: Harvesting was adding random amounts of berries (usually 2) instead of exactly 1 per harvest.
**Root Cause**: Both backend and frontend were adding berries to inventory when harvest completed, causing duplicate additions.
**Solution**: Removed the duplicate frontend berry addition since the backend already handles this correctly and syncs the inventory.

### Bug 2: Consuming Whole Stack Instead of One Berry
**Problem**: Eating/consuming berries was consuming the entire stack instead of just 1 berry.
**Root Cause**: The `removeItem` function was removing the entire item instead of decrementing the quantity.
**Solution**: Updated `removeItem` to be quantity-aware for stackable items like berries.

## Changes Made

### Frontend Changes
- **`frontend/src/Components/Api.tsx`**: Removed duplicate berry addition on harvest completion
- **`frontend/src/store.js`**: Updated `removeItem` function to handle quantities properly for stackable items
- **`frontend/src/Components/Inventory.tsx`**: Added optimistic UI updates for berry consumption
- **`frontend/src/__tests__/store.test.js`**: Updated tests to reflect new quantity-aware behavior and added specific berry consumption test

## Testing

- ✅ All frontend tests pass
- ✅ Added comprehensive test for berry consumption behavior
- ✅ Updated existing tests to match new quantity-aware removal logic

## Behavior After Fix

1. **Harvesting**: Now correctly adds exactly 1 berry per harvest completion
2. **Berry Consumption**: Now removes only 1 berry from stack, preserving remaining berries
3. **Inventory Sync**: Backend remains authoritative with proper inventory validation

## Breaking Changes

None - this is a bug fix that restores intended behavior.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author